### PR TITLE
Fix .html and .txt output so that thread-group labeling is the same and

### DIFF
--- a/src/main/resources/com/lazerycode/jmeter/analyzer/templates/html/aggregatedResponse.ftl
+++ b/src/main/resources/com/lazerycode/jmeter/analyzer/templates/html/aggregatedResponse.ftl
@@ -12,7 +12,7 @@
 <#-- @ftlvariable name="CHARTS" type="java.lang.Boolean" -->
 <#-- @ftlvariable name="DETAILS" type="java.lang.Boolean" -->
 <#-- @ftlvariable name="SUMMARY_FILE_NAME" type="java.lang.String" -->
-    <h2>Group ${key}</h2>
+    <h2>Group: ${key}</h2>
     <div class="aggregation">
       <h3>Summary</h3>
       <table>

--- a/src/main/resources/com/lazerycode/jmeter/analyzer/templates/text/aggregatedResponse.ftl
+++ b/src/main/resources/com/lazerycode/jmeter/analyzer/templates/text/aggregatedResponse.ftl
@@ -8,7 +8,7 @@
 <#-- @ftlvariable name="K_99_PERCENT" type="java.lang.Integer" -->
 <#-- @ftlvariable name="K_99_PONT_9_PERCENT" type="java.lang.Integer" -->
 <#-- @ftlvariable name="PERCENT_100" type="java.lang.Integer" -->
-${key}
+Group: ${key}
   time: ${aggregatedResponses.startDate?date?string} - ${aggregatedResponses.endDate?date?string}
   total duration:       ${requests.duration}
   requests:             ${requests.successCount}

--- a/src/test/java/com/lazerycode/jmeter/analyzer/writer/HtmlWriterTest.java
+++ b/src/test/java/com/lazerycode/jmeter/analyzer/writer/HtmlWriterTest.java
@@ -2,16 +2,15 @@ package com.lazerycode.jmeter.analyzer.writer;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.*;
-
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
 import static com.lazerycode.jmeter.analyzer.config.Environment.ENVIRONMENT;
 import static com.lazerycode.jmeter.analyzer.writer.WriterTestHelper.getMockedTestResults;
 import static com.lazerycode.jmeter.analyzer.writer.WriterTestHelper.normalizeFileContents;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-
 
 /**
  * Tests for {@link HtmlWriter}

--- a/src/test/resources/com/lazerycode/jmeter/analyzer/resultanalyzer/download/test.html
+++ b/src/test/resources/com/lazerycode/jmeter/analyzer/resultanalyzer/download/test.html
@@ -60,7 +60,7 @@
 <body>
   <h1>JMeter Summary</h1>
   <div class="aggregations">
-    <h2>Group warmup</h2>
+    <h2>Group: warmup</h2>
     <div class="aggregation">
       <h3>Summary</h3>
       <table>

--- a/src/test/resources/com/lazerycode/jmeter/analyzer/resultanalyzer/download/test.txt
+++ b/src/test/resources/com/lazerycode/jmeter/analyzer/resultanalyzer/download/test.txt
@@ -1,4 +1,4 @@
-warmup
+Group: warmup
   time: 20111216T145509+0100 - 20111216T145539+0100
   total duration:       30
   requests:             10

--- a/src/test/resources/com/lazerycode/jmeter/analyzer/resultanalyzer/samplenames/test.html
+++ b/src/test/resources/com/lazerycode/jmeter/analyzer/resultanalyzer/samplenames/test.html
@@ -60,7 +60,7 @@
 <body>
   <h1>JMeter Summary</h1>
   <div class="aggregations">
-    <h2>Group warmup</h2>
+    <h2>Group: warmup</h2>
     <div class="aggregation">
       <h3>Summary</h3>
       <table>

--- a/src/test/resources/com/lazerycode/jmeter/analyzer/resultanalyzer/samplenames/test.txt
+++ b/src/test/resources/com/lazerycode/jmeter/analyzer/resultanalyzer/samplenames/test.txt
@@ -1,4 +1,4 @@
-warmup
+Group: warmup
   time: 20111216T145511+0100 - 20111216T145511+0100
   total duration:       0
   requests:             1

--- a/src/test/resources/com/lazerycode/jmeter/analyzer/writer/test.html
+++ b/src/test/resources/com/lazerycode/jmeter/analyzer/writer/test.html
@@ -61,7 +61,7 @@
 <body>
   <h1>JMeter Summary</h1>
   <div class="aggregations">
-    <h2>Group warmup</h2>
+    <h2>Group: warmup</h2>
     <div class="aggregation">
       <h3>Summary</h3>
       <table>

--- a/src/test/resources/com/lazerycode/jmeter/analyzer/writer/test.txt
+++ b/src/test/resources/com/lazerycode/jmeter/analyzer/writer/test.txt
@@ -1,4 +1,4 @@
-warmup
+Group: warmup
   time: 20111216T145509+0100 - 20111216T145539+0100
   total duration:       30
   requests:             36049


### PR DESCRIPTION
Fix .html and .txt output so that thread-group labeling is the same and clearer.  As a beginner using this plugin, it wasn't very clear that the group name was actually printing at the top of each report section.