### PR TITLE
Replacing the spaces in the thread name with underscores instead of t…

### DIFF
--- a/src/main/java/com/lazerycode/jmeter/analyzer/parser/JMeterResultParser.java
+++ b/src/main/java/com/lazerycode/jmeter/analyzer/parser/JMeterResultParser.java
@@ -2,7 +2,6 @@ package com.lazerycode.jmeter.analyzer.parser;
 
 import static com.lazerycode.jmeter.analyzer.config.Environment.ENVIRONMENT;
 import static com.lazerycode.jmeter.analyzer.parser.StatusCodes.HTTPCODE_CONNECTIONERROR;
-import static com.lazerycode.jmeter.analyzer.parser.StatusCodes.HTTPCODE_ERROR;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -333,14 +332,9 @@ public class JMeterResultParser {
       else {
 
         // use threadgroup name as a key
-        key = attributes.getValue("tn");
-
-        //key is now "threadgroupname int-int"
-        int threadGroupSeparator = key.indexOf(' ');
-        if( threadGroupSeparator > -1) {
-          // cut off trailing threadno
-          key = key.substring(0, threadGroupSeparator);
-        }
+        key = attributes.getValue("tn").trim();
+        key = key.replaceAll("\\s+", "_");
+        //key is now "threadgroupname_int-int"
       }
 
       return key;

--- a/src/test/java/com/lazerycode/jmeter/analyzer/JMeterResultParserTest.java
+++ b/src/test/java/com/lazerycode/jmeter/analyzer/JMeterResultParserTest.java
@@ -1,12 +1,6 @@
 package com.lazerycode.jmeter.analyzer;
 
-import com.lazerycode.jmeter.analyzer.config.Environment;
-import com.lazerycode.jmeter.analyzer.parser.AggregatedResponses;
-import com.lazerycode.jmeter.analyzer.parser.JMeterResultParser;
-
-import junit.framework.TestCase;
-
-import org.apache.maven.plugin.logging.SystemStreamLog;
+import static com.lazerycode.jmeter.analyzer.config.Environment.ENVIRONMENT;
 
 import java.io.InputStreamReader;
 import java.util.ArrayList;
@@ -15,7 +9,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
-import static com.lazerycode.jmeter.analyzer.config.Environment.ENVIRONMENT;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+
+import com.lazerycode.jmeter.analyzer.config.Environment;
+import com.lazerycode.jmeter.analyzer.parser.AggregatedResponses;
+import com.lazerycode.jmeter.analyzer.parser.JMeterResultParser;
+import junit.framework.TestCase;
 
 /**
  * Tests {@link JMeterResultParser}
@@ -35,9 +34,10 @@ public class JMeterResultParserTest extends TestCase {
 
     assertEquals("size", 1, result.size());
 
-    AggregatedResponses r = result.get("warmup");
+    AggregatedResponses r = result.get("warmup_3-1");
 
     // test requests
+    assertNotNull(r);
     assertEquals("samples", 10, r.getDuration().getStoredSamplesCount());
     assertEquals("success", 10, r.getDuration().getSuccessCount());
     assertEquals("failure", 0, r.getDuration().getErrorsCount());
@@ -51,11 +51,12 @@ public class JMeterResultParserTest extends TestCase {
     JMeterResultParser a = new JMeterResultParser();
     Map<String, AggregatedResponses> result = a.aggregate(new InputStreamReader(getClass().getResourceAsStream("JMeterResultParserTest-differentNodeNames.xml")));
 
-    assertEquals("size", 1, result.size());
+    assertEquals("size", 2, result.size());
 
-    AggregatedResponses r = result.get("warmup");
+    AggregatedResponses r = result.get("warmup_3-1");
 
     // test requests
+    assertNotNull(r);
     assertEquals("samples", 3, r.getDuration().getStoredSamplesCount());
     assertEquals("success", 3, r.getDuration().getSuccessCount());
     assertEquals("failure", 0, r.getDuration().getErrorsCount());
@@ -68,9 +69,10 @@ public class JMeterResultParserTest extends TestCase {
 
     assertEquals("size", 1, result.size());
 
-    AggregatedResponses r = result.get("warmup");
+    AggregatedResponses r = result.get("warmup_3-1");
 
     // test requests
+    assertNotNull(r);
     assertEquals("samples", 1, r.getDuration().getStoredSamplesCount());
     assertEquals("success", 1, r.getDuration().getSuccessCount());
     assertEquals("failure", 2, r.getDuration().getErrorsCount());
@@ -83,9 +85,10 @@ public class JMeterResultParserTest extends TestCase {
 
     assertEquals("size", 1, result.size());
 
-    AggregatedResponses r = result.get("warmup");
+    AggregatedResponses r = result.get("warmup_3-1");
 
     // test requests
+    assertNotNull(r);
     assertEquals("samples", 0, r.getDuration().getStoredSamplesCount());
     assertEquals("success", 0, r.getDuration().getSuccessCount());
     assertEquals("failure", 3, r.getDuration().getErrorsCount());
@@ -125,6 +128,18 @@ public class JMeterResultParserTest extends TestCase {
     assertEquals("samples", 4, r.getDuration().getStoredSamplesCount());
     assertEquals("success", 4, r.getDuration().getSuccessCount());
     assertEquals("failure", 0, r.getDuration().getErrorsCount());
+  }
+
+  public void testSpacesAreReplacedWithUnderscoresInTestName() throws Exception {
+    JMeterResultParser a = new JMeterResultParser();
+    Map<String, AggregatedResponses> result = a.aggregate(new InputStreamReader(getClass().getResourceAsStream("JMeterResultParserTest-differentNodeNames.xml")));
+
+    assertEquals("size", 2, result.size());
+
+    AggregatedResponses r = result.get("test_name_with_spaces");
+
+    // test requests
+    assertNotNull(r);
   }
 
   // TODO: more tests

--- a/src/test/resources/com/lazerycode/jmeter/analyzer/JMeterResultParserTest-differentNodeNames.xml
+++ b/src/test/resources/com/lazerycode/jmeter/analyzer/JMeterResultParserTest-differentNodeNames.xml
@@ -3,4 +3,5 @@
   <httpSample t="1403" lt="1224" ts="1316697692340" s="true" lb="/main" rc="200" rm="OK" tn="warmup 3-1" dt="text" by="53890"/>
   <sample t="19" lt="19" ts="1316697693748" s="true" lb="/main/6/data" rc="200" rm="OK" tn="warmup 3-1" dt="bin" by="20480"/>
   <httpSample t="4" lt="4" ts="1316697693767" s="true" lb="/main/10/data" rc="200" rm="OK" tn="warmup 3-1" dt="bin" by="20480"/>
+  <sample t="58" lt="58" ts="1316697693798" s="true" lb="/main/8/data" rc="200" rm="OK" tn="test name with spaces" dt="bin" by="20480"/>
 </testResults>

--- a/src/test/resources/com/lazerycode/jmeter/analyzer/resultanalyzer/download/test.html
+++ b/src/test/resources/com/lazerycode/jmeter/analyzer/resultanalyzer/download/test.html
@@ -60,7 +60,7 @@
 <body>
   <h1>JMeter Summary</h1>
   <div class="aggregations">
-    <h2>Group: warmup</h2>
+    <h2>Group: warmup_1-1</h2>
     <div class="aggregation">
       <h3>Summary</h3>
       <table>

--- a/src/test/resources/com/lazerycode/jmeter/analyzer/resultanalyzer/download/test.txt
+++ b/src/test/resources/com/lazerycode/jmeter/analyzer/resultanalyzer/download/test.txt
@@ -1,4 +1,4 @@
-Group: warmup
+Group: warmup_1-1
   time: 20111216T145509+0100 - 20111216T145539+0100
   total duration:       30
   requests:             10

--- a/src/test/resources/com/lazerycode/jmeter/analyzer/resultanalyzer/samplenames/test.html
+++ b/src/test/resources/com/lazerycode/jmeter/analyzer/resultanalyzer/samplenames/test.html
@@ -60,7 +60,7 @@
 <body>
   <h1>JMeter Summary</h1>
   <div class="aggregations">
-    <h2>Group: warmup</h2>
+    <h2>Group: warmup_1-1</h2>
     <div class="aggregation">
       <h3>Summary</h3>
       <table>

--- a/src/test/resources/com/lazerycode/jmeter/analyzer/resultanalyzer/samplenames/test.txt
+++ b/src/test/resources/com/lazerycode/jmeter/analyzer/resultanalyzer/samplenames/test.txt
@@ -1,4 +1,4 @@
-Group: warmup
+Group: warmup_1-1
   time: 20111216T145511+0100 - 20111216T145511+0100
   total duration:       0
   requests:             1


### PR DESCRIPTION
…runcating the key after the first space.

This is to resolve the issue#30.
https://github.com/afranken/jmeter-analysis-maven-plugin/issues/30